### PR TITLE
Fix sequence numbers in filenames

### DIFF
--- a/src/ExportManager.cpp
+++ b/src/ExportManager.cpp
@@ -280,7 +280,7 @@ QString ExportManager::formattedFilename(const QString &nameTemplate) const
             if (filteredFiles.length() > 0) {
                 // loop through filtered file names looking for highest number
                 for (const QString &filteredFile : filteredFiles) {
-                    int currentFileNumber = fileNumberRE.match(filteredFile).captured(1).length();
+                    int currentFileNumber = fileNumberRE.match(filteredFile).captured(1).toInt();
                     if (currentFileNumber > highestFileNumber) {
                         highestFileNumber = currentFileNumber;
                     }

--- a/tests/FilenameTest.cpp
+++ b/tests/FilenameTest.cpp
@@ -87,15 +87,20 @@ void FilenameTest::testNumbering()
     QCOMPARE(mExportManager->formattedFilename(BaseName + u"_<####>"_s), BaseName + u"_0001"_s);
     QCOMPARE(mExportManager->formattedFilename(BaseName + u"_<#>_<##>_<###>"_s), BaseName + u"_1_01_001"_s);
 
-    QFile file(QDir(mExportManager->defaultSaveLocation()).filePath(BaseName + u"_1.png"_s));
+    QFile file(QDir(mExportManager->defaultSaveLocation()).filePath(BaseName + u"_3.png"_s));
     file.open(QIODevice::WriteOnly);
     file.close();
-    QCOMPARE(mExportManager->formattedFilename(BaseName + u"_<#>"_s), BaseName + u"_2"_s);
+    QCOMPARE(mExportManager->formattedFilename(BaseName + u"_<#>"_s), BaseName + u"_4"_s);
     file.remove();
-    file.setFileName(QDir(mExportManager->defaultSaveLocation()).filePath(BaseName + u"_1_01_001"_s));
+    file.setFileName(QDir(mExportManager->defaultSaveLocation()).filePath(BaseName + u"_0008"_s));
     file.open(QIODevice::WriteOnly);
     file.close();
-    QCOMPARE(mExportManager->formattedFilename(BaseName + u"_<#>_<##>_<###>"_s), BaseName + u"_2_02_002"_s);
+    QCOMPARE(mExportManager->formattedFilename(BaseName + u"_<####>"_s), BaseName + u"_0009"_s);
+    file.remove();
+    file.setFileName(QDir(mExportManager->defaultSaveLocation()).filePath(BaseName + u"_7_07_007"_s));
+    file.open(QIODevice::WriteOnly);
+    file.close();
+    QCOMPARE(mExportManager->formattedFilename(BaseName + u"_<#>_<##>_<###>"_s), BaseName + u"_8_08_008"_s);
     file.remove();
 }
 


### PR DESCRIPTION
This seems to have been a minor regression from ebee5b1d413eeba6a79f65160bc6cc1e543fdad1 that changed sequence numbers to be filled with padded length + 1 instead of highest sequence number + 1 if there was a previous file. The tests didn't catch it because the sequence number and string length were both 1.

BUG: 483260